### PR TITLE
Removing unnecessary synchronization

### DIFF
--- a/SimpleMandelbrotDemo/src/ui/ForkMandelbrot.java
+++ b/SimpleMandelbrotDemo/src/ui/ForkMandelbrot.java
@@ -65,10 +65,7 @@ public class ForkMandelbrot extends RecursiveAction {
 			}
 
 			if (!isBenchmarking && mandelbrot.isLiveRendering) {
-				synchronized (mandelbrot.lock) {
-					mandelbrot.renderImage.setRGB(j, i, color.getRGB());
-				}
-				
+				mandelbrot.renderImage.setRGB(j, i, color.getRGB());
 				mandelbrot.repaint();
 			} else {
 				mandelbrot.imageArray[i * mandelbrot.width + j] = color.getRGB();


### PR DESCRIPTION
Hi @catree, 

since the method `.setRGB` is already synchronized, aren't you oversynchronizing? 

I benchmarked it on my machine, and it does not seem to be racy. Also just by removing this synchronization we can save about 40% in performance and energy consumption.

Gustavo
